### PR TITLE
Allow unescaped options for boolean columns

### DIFF
--- a/src/resources/views/columns/boolean.blade.php
+++ b/src/resources/views/columns/boolean.blade.php
@@ -2,13 +2,21 @@
 <td data-order="{{ $entry->{$column['name']} }}">
 	@if ($entry->{$column['name']} === true || $entry->{$column['name']} === 1 || $entry->{$column['name']} === '1')
         @if ( isset( $column['options'][1] ) )
-            {{ $column['options'][1] }}
+            @if ( isset( $column['options']['unesc'] )  && $column['options']['unesc'])
+                {!! $column['options'][1] !!}
+            @else
+                {{ $column['options'][1] }}
+            @endif
         @else
             {{ Lang::has('backpack::crud.yes')?trans('backpack::crud.yes'):'Yes' }}
         @endif
     @else
         @if ( isset( $column['options'][0] ) )
-            {{ $column['options'][0] }}
+            @if ( isset( $column['options']['unesc'] )  && $column['options']['unesc'])
+                {!! $column['options'][0] !!}
+            @else
+                {{ $column['options'][0] }}
+            @endif
         @else
             {{ Lang::has('backpack::crud.no')?trans('backpack::crud.no'):'No' }}
         @endif


### PR DESCRIPTION
Adding additional optional param to $column['options'] called `unsec` allowing for unescaped from the default `htmlspecialchars` filter on `{{ }}` and uses `{!! !!}` instead.

It is best to keep using the escaped data for security however some cases it would be nice to have the option for sending html.

Example: I want to display a checkmark/times depending on if it is yes/no using font awesome which requires passing html.